### PR TITLE
Fix comment, timestamp bug, and add truncateString test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Paxcounter M5Stack
+
+This repository contains an Arduino sketch for counting nearby Bluetooth devices. A small unit test is provided for the `truncateString` helper.
+
+## Running the test
+
+1. Install the GoogleTest development package (Ubuntu example):
+   ```bash
+   sudo apt-get install libgtest-dev googletest
+   ```
+2. Build the test:
+   ```bash
+   g++ -std=c++17 truncateString.cpp tests/test_truncateString.cpp \
+       -lgtest -lgtest_main -pthread -o tests/test_truncateString
+   ```
+3. Run it:
+   ```bash
+   ./tests/test_truncateString
+   ```

--- a/paxcounterm5top10.ino
+++ b/paxcounterm5top10.ino
@@ -75,7 +75,7 @@ const std::string CLS_TAG       = "Tag";
 const std::string CLS_IBEACON   = "iBeacon";
 const std::string CLS_EDDYSTONE = "Eddystone";
 const std::string CLS_SENSOR    = "Sensor";
-const std::string CLS_MESHTASTIC= "Meshtastic";
+const std::string CLS_MESHTASTIC = "Meshtastic";
 const std::string CLS_HID       = "HID";
 const std::string CLS_OTHER_BLE = "OtherBLE";
 const std::string CLS_UNKNOWN   = "Unknown";
@@ -145,7 +145,7 @@ std::string classifyDevice(BLEAdvertisedDevice& device);
 std::string truncateString(const std::string& str, size_t width);
 void processActivityData();
 void updatePaxCountDisplay();
-void updateDetailDisplay(); // Renamed
+void updateDetailDisplay(); // Updates detailed information on the display
 
 void setup() {
     auto cfg = M5.config();
@@ -205,7 +205,7 @@ void loop() {
             }
 
             if (macs_sighted_this_scan_cycle.find(mac_key) == macs_sighted_this_scan_cycle.end()) {
-                activity.detection_timestamps.push_back(current_time_ms);
+                activity.detection_timestamps.push_back(millis());
                 macs_sighted_this_scan_cycle.insert(mac_key);
             }
         }

--- a/tests/test_truncateString.cpp
+++ b/tests/test_truncateString.cpp
@@ -1,0 +1,17 @@
+#include <gtest/gtest.h>
+#include "truncateString.h"
+
+TEST(TruncateStringTest, ShorterStringUnchanged) {
+    std::string input = "abc";
+    EXPECT_EQ("abc", truncateString(input, 5));
+}
+
+TEST(TruncateStringTest, LongerStringTruncated) {
+    std::string input = "abcdef";
+    EXPECT_EQ("abcd.", truncateString(input, 5));
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/truncateString.cpp
+++ b/truncateString.cpp
@@ -1,0 +1,15 @@
+#include "truncateString.h"
+#include <string>
+
+std::string truncateString(const std::string& str, size_t width) {
+    if (str.length() > width) {
+        if (width > 1) {
+            return str.substr(0, width - 1) + ".";
+        } else if (width == 1) {
+            return str.substr(0, 1);
+        } else {
+            return "";
+        }
+    }
+    return str;
+}

--- a/truncateString.h
+++ b/truncateString.h
@@ -1,0 +1,5 @@
+#ifndef TRUNCATESTRING_H
+#define TRUNCATESTRING_H
+#include <string>
+std::string truncateString(const std::string& str, size_t width);
+#endif


### PR DESCRIPTION
## Summary
- clean up Meshtastic classification constant spacing
- store BLE detection timestamps at actual detection time
- clarify the `updateDetailDisplay` prototype comment
- provide a small `truncateString` helper library
- add GoogleTest-based unit test for `truncateString`
- include basic test build instructions in `README.md`

## Testing
- `g++ -std=c++17 -I. truncateString.cpp tests/test_truncateString.cpp -lgtest -lgtest_main -pthread -o tests/test_truncateString && tests/test_truncateString`

------
https://chatgpt.com/codex/tasks/task_e_683fa1fad3e4832dbca7f54fec4aab30