### PR TITLE
fix: Correct M5.Touch API call for Core2 touch input

### DIFF
--- a/paxcounterm5top10.ino
+++ b/paxcounterm5top10.ino
@@ -321,7 +321,7 @@ void loop() {
     if (touch_count > 0) {
         lgfx::v1::touch_point_t tp;
         // Consider the first touch point for simplicity
-        M5.Touch.getPoint(&tp, 0);
+        M5.Touch.getDetail(&tp, 0);
 
         if (tp.y >= TOUCH_BTN_Y_MIN && tp.y <= TOUCH_BTN_Y_MAX) {
             if (tp.x >= TOUCH_BTN_A_X_MIN && tp.x <= TOUCH_BTN_A_X_MAX) {


### PR DESCRIPTION
Replaced `M5.Touch.getPoint(&tp, 0)` with `M5.Touch.getDetail(&tp, 0)` to correctly retrieve touch point details using the M5Unified library. This resolves a compilation error you encountered when implementing touch-based filter controls for the M5Stack Core2.