### PR TITLE
fix: Correct M5.Touch.getDetail API usage for Core2

### DIFF
--- a/paxcounterm5top10.ino
+++ b/paxcounterm5top10.ino
@@ -321,7 +321,7 @@ void loop() {
     if (touch_count > 0) {
         lgfx::v1::touch_point_t tp;
         // Consider the first touch point for simplicity
-        M5.Touch.getDetail(&tp, 0);
+        tp = M5.Touch.getDetail(0);
 
         if (tp.y >= TOUCH_BTN_Y_MIN && tp.y <= TOUCH_BTN_Y_MAX) {
             if (tp.x >= TOUCH_BTN_A_X_MIN && tp.x <= TOUCH_BTN_A_X_MAX) {


### PR DESCRIPTION
Changed the method of retrieving touch point details from `M5.Touch.getDetail(&tp, 0)` to `tp = M5.Touch.getDetail(0)`. This uses the correct API pattern where the touch_point_t struct is returned by value and assigned, resolving a compilation error for M5Stack Core2 touch input handling.